### PR TITLE
:sparkles: Add first features of the `hit info` command

### DIFF
--- a/src/general/generalCommands.ts
+++ b/src/general/generalCommands.ts
@@ -1,0 +1,12 @@
+import * as program from 'commander';
+import { getGeneralInformation } from './generalModule';
+
+export const initGeneralCommands = async () => {
+  program
+    .command('info')
+    .alias('i')
+    .description('Get general information about the repository')
+    .action(async () => {
+      await getGeneralInformation();
+    });
+}

--- a/src/general/generalModule.ts
+++ b/src/general/generalModule.ts
@@ -1,0 +1,63 @@
+import chalk from 'chalk';
+import { writeError } from './../helper/cmd';
+import { Repository, Reference, Commit} from 'nodegit';
+import { openRepository, getBranchRefFromName, getShortNameFromRef, getRemoteOrigin } from "../helper/git";
+
+export const getGeneralInformation = async () => {
+  /* information to show:
+   * - current branch
+   * - latest commit
+   * - remote origin (if exists)
+   * - how many commits ahead or behind of master (if it's a branch)
+   * - if it the commit is ahead or behind of origin/master
+  */ 
+
+  // open repo
+  const repo: Repository | undefined = await openRepository();
+  if(typeof repo === 'undefined'){
+    return;
+  }
+
+  // get current branch
+  const currentBranch: Reference = await repo.getCurrentBranch();
+
+  // branch name
+  const branchName = getShortNameFromRef(currentBranch);
+  // get latest branch commit
+  const refCommit: Commit = await repo.getReferenceCommit(currentBranch);
+  const refCommitShortSha = refCommit.sha().slice(0, 7);
+  // get master commit
+  const masterCommit: Commit = await repo.getMasterCommit();
+  const masterCommitShortSha = masterCommit.sha().slice(0, 7);
+  // whether the branch has the latest commit from master
+  const refCommitIsUpToDate: boolean = refCommitShortSha === masterCommitShortSha;
+
+
+  const writeInfoMessage = (param1: string, param2: string) => {
+    console.log(`[ ${chalk.hex('#16a085').bold('info')} ] ${chalk.hex('#1abc9c').bold(param1)} -> ${chalk.hex('#1abc9c')(param2)}`);
+  }
+  // empty line
+  console.log();
+  
+  // current branch name
+  writeInfoMessage('Current branch', branchName)
+
+  // color of master will be red if the head commit of branch and master doesn't match 
+  let masterCommitInColor = chalk.red(masterCommitShortSha);
+  if(refCommitIsUpToDate === true) {
+    // ... green if they do match
+    masterCommitInColor = chalk.green(masterCommitShortSha);
+  }
+
+  // head commit
+  writeInfoMessage('Head Commit', `${refCommitShortSha} ${chalk.grey('[master ' + masterCommitInColor + ']')}` )
+  
+  // get remotes
+  const remoteOrigin = await getRemoteOrigin(repo);
+  
+  writeInfoMessage('Remote origin', `${remoteOrigin.url()}`)
+
+  console.log();
+
+
+}

--- a/src/helper/git.ts
+++ b/src/helper/git.ts
@@ -1,4 +1,4 @@
-import { Repository, Reference, Branch } from 'nodegit';
+import { Repository, Reference, Branch, Remote } from 'nodegit';
 import { writeError } from './cmd';
 /**
  * Opens the repository at the cwd and returns it to work with ti
@@ -38,4 +38,8 @@ export function getShortNameFromRef(ref: Reference) {
 
 export function deleteBranch(ref: Reference){
   return Branch.delete(ref);
+}
+
+export async function getRemoteOrigin(repo: Repository) {
+  return await Remote.lookup(repo, 'origin', () => true)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
 import { initBranchCommands } from './branch/branchCommands';
-
+import { initGeneralCommands } from './general/generalCommands';
 initBranchCommands();
+initGeneralCommands();


### PR DESCRIPTION
Added the `hit info` command and made it print out the current branche's name, the current HEAD commit and compare this commit with the master's HEAD commit) and the remote push url